### PR TITLE
Fast LED chip + color order

### DIFF
--- a/src/blocks/fastled/blocks.ts
+++ b/src/blocks/fastled/blocks.ts
@@ -54,6 +54,64 @@ Blockly.Blocks['fastled_setup'] = {
         'PIN'
       );
     this.appendDummyInput()
+      .appendField('Type')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['WS2811', 'WS2811'],
+          ['WS2801', 'WS2801'],
+          ['WS2803', 'WS2803'],
+          ['APA102', 'APA102'],
+          ['APA104', 'APA104'],
+          ['APA106', 'APA106'],
+          ['DOTSTAR', 'DOTSTAR'],
+          ['GE8822', 'GE8822'],
+          ['GS1903', 'GS1903'],
+          ['GW6205', 'GW6205'],
+          ['GW6205_400', 'GW6205_400'],
+          ['LPD1886', 'LPD1886'],
+          ['LPD1886_8BIT', 'LPD1886_8BIT'],
+          ['LPD6803', 'LPD6803'],
+          ['LPD8806', 'LPD8806'],
+          ['P9813', 'P9813'],
+          ['PL9823', 'PL9823'],
+          ['SK6812', 'SK6812'],
+          ['SK6822', 'SK6822'],
+          ['SK9822', 'SK9822'],
+          ['SM16703', 'SM16703'],
+          ['SM16716', 'SM16716'],
+          ['TM1803', 'TM1803'],
+          ['TM1804', 'TM1804'],
+          ['TM1809', 'TM1809'],
+          ['TM1812', 'TM1812'],
+          ['TM1829', 'TM1829'],
+          ['UCS1903', 'UCS1903'],
+          ['UCS1903B', 'UCS1903B'],
+          ['UCS1904', 'UCS1904'],
+          ['UCS2903', 'UCS2903'],
+          ['WS2811_400', 'WS2811_400'],
+          ['WS2812', 'WS2812'],
+          ['WS2812B', 'WS2812B'],
+          ['WS2813', 'WS2813'],
+          ['WS2852', 'WS2852'],
+        ]),
+        'CHIP_SET'
+      );
+
+    this.appendDummyInput()
+      .appendField('Color Order')
+      .appendField(
+        new Blockly.FieldDropdown([
+          ['RGB', 'RGB'],
+          ['GRB', 'GRB'],
+          ['RBG', 'RBG'],
+          ['GBR', 'GBR'],
+          ['BRG', 'BRG'],
+          ['BGR', 'BGR'],
+        ]),
+        'COLOR_ORDER'
+      );
+
+    this.appendDummyInput()
       .appendField('Number of leds')
       .appendField(new Blockly.FieldNumber(30, 1, 150), 'NUMBER_LEDS');
     this.appendDummyInput()

--- a/src/blocks/fastled/generators.ts
+++ b/src/blocks/fastled/generators.ts
@@ -5,17 +5,18 @@ Blockly['Arduino']['fastled_setup'] = function (block) {
   const numberOfLeds = block.getFieldValue('NUMBER_LEDS');
   const pin = block.getFieldValue('PIN');
   const brightness = block.getFieldValue('BRIGHTNESS');
+  const colorOrder = block.getFieldValue('COLOR_ORDER');
+  const chipSet = block.getFieldValue('CHIP_SET');
   Blockly['Arduino'].libraries_['define_fastled'] = `
 #include <FastLED.h>
 #define NUM_LEDS ${numberOfLeds}
 #define DATA_PIN ${pin} 
-#define COLOR_ORDER GRB
 CRGB leds[NUM_LEDS];
 
 `;
 
   Blockly['Arduino'].setupCode_['fastled'] = `
-    FastLED.addLeds<WS2811, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS);
+    FastLED.addLeds<${chipSet}, DATA_PIN, ${colorOrder}>(leds, NUM_LEDS);
     FastLED.setBrightness(${brightness});    
 `;
   return '';


### PR DESCRIPTION
## Purpose

To add chipset and color order to the FAST LED Block.

I went through all the chipsets in this list and picked the ones that compiled.

Also added color order as well.

https://github.com/FastLED/FastLED/blob/b5874b588ade1d2639925e4e9719fa7d3c9d9e94/keywords.txt

## New Block 

![Screen Shot 2021-12-09 at 9 08 30 PM](https://user-images.githubusercontent.com/9620015/145520550-a6f081ed-b9de-43e5-80bf-71dab1bc0919.png)



