### PR TITLE
Fixing Serial Monitor Code

### DIFF
--- a/src/blocks/arduino/generators.ts
+++ b/src/blocks/arduino/generators.ts
@@ -1,5 +1,5 @@
 import Blockly from "blockly";
-import type { Block } from "blockly";
+import { Block } from "blockly";
 import _ from "lodash";
 
 Blockly["Arduino"]["arduino_setup"] = function (block: Block) {
@@ -31,9 +31,12 @@ Blockly["Arduino"]["arduino_loop"] = function (block: Block) {
     setJoyStickValues = "\tsetJoyStickValues(); \n";
   }
 
-  if (!_.isEmpty(Blockly["Arduino"].setupCode_["serial_begin"])) {
-    resetMessageVariable = '\tserialMessageDEV= ""; \n';
-    setSerialMessageDEV = "\tsetSerialMessage();";
+  if (
+    !_.isEmpty(Blockly["Arduino"].setupCode_["serial_begin"]) &&
+    Blockly["Arduino"].information_["message_recieve_block"]
+  ) {
+    resetMessageVariable = ' serialMessageDEV= ""; \n';
+    setSerialMessageDEV = "  setSerialMessage();\n";
   }
 
   if (!_.isEmpty(Blockly["Arduino"].setupCode_["setup_ir_remote"])) {

--- a/src/blocks/debug/generators.ts
+++ b/src/blocks/debug/generators.ts
@@ -5,6 +5,16 @@ import { stepSerialBegin } from "../message/generators";
 Blockly["Arduino"]["debug_block"] = function (block) {
   stepSerialBegin();
 
+  Blockly["Arduino"].setupCode_["debug_clean_pipes"] =
+    "\tdelay(200); // to prevent noise after uploading code \n";
+
+  Blockly["Arduino"].setupCode_[
+    "debug_wait_til_ok"
+  ] = `while(Serial.readStringUntil('|').indexOf("START_DEBUG") == -1) {
+      Serial.println("C_D_B_C_D_B_C_D_B_C_D_B_C_D_B_");
+      delay(100);
+  }\n\n`;
+
   Blockly["Arduino"].functionNames_["double_to_string_debug"] =
     createDoubleToStringCFunc();
 

--- a/src/blocks/led/blocktoframe.ts
+++ b/src/blocks/led/blocktoframe.ts
@@ -12,7 +12,6 @@ export const led: BlockToFrameTransformer = (
   timeline,
   previousState
 ) => {
-  console.log(block);
   const pin = findFieldValue(block, "PIN");
   const color = findFieldValue(block, "COLOR");
   const state = findFieldValue(block, "STATE") === "ON" ? 1 : 0;

--- a/src/blocks/message/generators.ts
+++ b/src/blocks/message/generators.ts
@@ -7,20 +7,15 @@ export function stepSerialBegin() {
     selectBoardBlockly().serial_baud_rate +
     "); \n" +
     "\tSerial.setTimeout(10);\n";
-
-  Blockly["Arduino"].setupCode_["debug_clean_pipes"] =
-    "\tdelay(200); // to prevent noise after uploading code \n";
-
-  Blockly["Arduino"].setupCode_[
-    "debug_wait_til_ok"
-  ] = `while(Serial.readStringUntil('|').indexOf("START_DEBUG") == -1) {
-      Serial.println("C_D_B_C_D_B_C_D_B_C_D_B_C_D_B_");
-      delay(100);
-  }\n\n`;
 }
 
 Blockly["Arduino"]["message_setup"] = function () {
   stepSerialBegin();
+
+  return "";
+};
+
+Blockly["Arduino"]["arduino_get_message"] = function (block) {
   Blockly["Arduino"].functionNames_[
     "setSerialMessage"
   ] = `void setSerialMessage() {
@@ -30,18 +25,26 @@ Blockly["Arduino"]["message_setup"] = function () {
   }
 };
   `;
-  return "";
-};
-
-Blockly["Arduino"]["arduino_get_message"] = function (block) {
   return ["serialMessageDEV", Blockly["Arduino"].ORDER_ATOMIC];
 };
 
 Blockly["Arduino"]["arduino_receive_message"] = function (block) {
+  Blockly["Arduino"].information_["message_recieve_block"] = true;
+  Blockly["Arduino"].functionNames_[
+    "setSerialMessage"
+  ] = `void setSerialMessage() {
+  if (Serial.available() > 0) {
+      serialMessageDEV = Serial.readString();
+      serialMessageDEV.trim();      
+  }
+};
+  `;
   return ["(serialMessageDEV.length() > 0)", Blockly["Arduino"].ORDER_ATOMIC];
 };
 
 Blockly["Arduino"]["arduino_send_message"] = function (block) {
+  Blockly["Arduino"].information_["message_recieve_block"] = true;
+
   const message = Blockly["Arduino"].valueToCode(
     block,
     "MESSAGE",

--- a/src/blocks/message/generators.ts
+++ b/src/blocks/message/generators.ts
@@ -16,6 +16,8 @@ Blockly["Arduino"]["message_setup"] = function () {
 };
 
 Blockly["Arduino"]["arduino_get_message"] = function (block) {
+  Blockly["Arduino"].information_["message_recieve_block"] = true;
+
   Blockly["Arduino"].functionNames_[
     "setSerialMessage"
   ] = `void setSerialMessage() {
@@ -43,8 +45,6 @@ Blockly["Arduino"]["arduino_receive_message"] = function (block) {
 };
 
 Blockly["Arduino"]["arduino_send_message"] = function (block) {
-  Blockly["Arduino"].information_["message_recieve_block"] = true;
-
   const message = Blockly["Arduino"].valueToCode(
     block,
     "MESSAGE",

--- a/src/core/blockly/generators/arduino.ts
+++ b/src/core/blockly/generators/arduino.ts
@@ -76,6 +76,7 @@ Blockly["Arduino"].init = function (workspace) {
 
   // creates a list of code to be setup before the setup block
   Blockly["Arduino"].setupCode_ = Object.create(null);
+  Blockly["Arduino"].information_ = Object.create(null);
 
   // Create a dictionary mapping desired function names in definitions_
   // to actual function names (to avoid collisions with user functions).


### PR DESCRIPTION
# Purpose

Right now, the debug block code is mixed with the serial monitor code.  We want to separate out the two and only show the read serial monitor code when a read serial monitor block is being used.