### PR TITLE
LCD Screen Print Block FIx

### DIFF
--- a/src/blocks/lcd_screen/generators.ts
+++ b/src/blocks/lcd_screen/generators.ts
@@ -74,7 +74,7 @@ Blockly["Arduino"]["lcd_screen_simple_print"] = function (
   );
 
   function printRow(row, textRow) {
-    return textRow !== '""'
+    return textRow !== '""' && textRow !== ""
       ? "lcd.setCursor(0, " + row + "); \n" + "lcd.print(" + textRow + "); \n"
       : "";
   }


### PR DESCRIPTION
# Purpose

Get the print block working when no text block is connected.  It looks like it's doing the right thing, but I will test it out when I get home.