### PR TITLE
Added dropdown for language selection.

### DIFF
--- a/src/firebase/model.ts
+++ b/src/firebase/model.ts
@@ -38,4 +38,5 @@ export const defaultSetting: Settings = {
   customLedColor: false,
   maxTimePerMove: 20,
   boardType: MicroControllerType.ARDUINO_UNO,
+  language: "C",
 };

--- a/src/routes/(blockly)/code/+page.svelte
+++ b/src/routes/(blockly)/code/+page.svelte
@@ -2,8 +2,11 @@
   import { onMount } from "svelte";
   import codeStore from "../../../stores/code.store";
   
+  //Import hljs generator for Python
   import hljs from 'highlight.js/lib/core';
   import arduinoLang from 'highlight.js/lib/languages/arduino';
+  import pythonLang from 'highlight.js/lib/languages/python';
+
   import 'highlight.js/styles/arduino-light.css';
   import 'highlight.js/styles/a11y-light.css';
 
@@ -17,14 +20,16 @@
   let hasCopiedCode = false;
   onMount(async () => {
     hljs.registerLanguage('arduino', arduinoLang);
+    hljs.registerLanguage('python', pythonLang);
     codeStore.subscribe(async (codeInfo) => {
-      try
-      {
-        // @ts-ignore
-        code =  hljs.highlight(codeInfo.code,{ language: 'arduino' }).value;
-
-      }
-      catch(e)
+      try {
+        if (codeInfo.boardType==="python") {
+          code = hljs.highlight(codeInfo.code, { language: 'python'}).value;
+        } else {
+          // @ts-ignore
+          code =  hljs.highlight(codeInfo.code,{ language: 'arduino' }).value;
+        }
+      }catch(e)
       {
         console.log(e);
       }
@@ -88,7 +93,8 @@
   </div>
 </div>
 <pre style="font-size: {fontSize}px">
-  <code class="language-arduino">{@html code}</code>
+  <code class="{get(codeStore).boardType === 'python' ? 'language-python' : 'language-arduino'}">{@html code}</code>
+
 </pre>
 <svelte:head>
   <title>ElectroBlocks - Code</title>

--- a/src/routes/(blockly)/settings/+page.svelte
+++ b/src/routes/(blockly)/settings/+page.svelte
@@ -34,12 +34,8 @@
     if (settings.language === "Python") {
       codeStore.resetPythonCode();
       console.log("Resetting to Python");
-    } else if (settings.language === "C") {
-      codeStore.resetCode(MicroControllerType.ARDUINO_UNO);
-      console.log("Resetting to C");
     }
   }
-
   
   async function onSaveSettings() {
     await saveSettings(settings);

--- a/src/routes/(blockly)/settings/+page.svelte
+++ b/src/routes/(blockly)/settings/+page.svelte
@@ -6,6 +6,9 @@
   import { fbSaveSettings } from "../../../firebase/db";
   import authStore from "../../../stores/auth.store";
   import settingsStore from "../../../stores/settings.store";
+
+  import codeStore from "../../../stores/code.store";
+  
   import FlashMessage from "../../../components/electroblocks/ui/FlashMessage.svelte";
   import _ from "lodash";
   import { onErrorMessage } from "../../../help/alerts";
@@ -19,10 +22,25 @@
 
   let previousSettings = null;
 
+
+
   settingsStore.subscribe((newSettings) => {
     settings = newSettings;
   });
 
+  
+  $: if (settings) {
+    console.log("Language Selector Changed", settings.language);
+    if (settings.language === "Python") {
+      codeStore.resetPythonCode();
+      console.log("Resetting to Python");
+    } else if (settings.language === "C") {
+      codeStore.resetCode(MicroControllerType.ARDUINO_UNO);
+      console.log("Resetting to C");
+    }
+  }
+
+  
   async function onSaveSettings() {
     await saveSettings(settings);
   }
@@ -86,6 +104,23 @@
       </FormGroup>
     </div>
   </div>
+
+  <div class="row">
+    <div class="col">
+      <FormGroup>
+      <Label for="lang-select">Select Language </Label>
+      <Input
+        bind:value={settings.language}
+        type="select"
+        id="lang-select"
+      >
+        <option>Python</option>
+        <option>C</option>
+      </Input>
+      </FormGroup>
+    </div>
+  </div>
+
 
   <div class="row">
     <div class="col">

--- a/src/stores/code.store.ts
+++ b/src/stores/code.store.ts
@@ -25,9 +25,14 @@ const codeStore = writable({
   boardType: MicroControllerType.ARDUINO_UNO,
 });
 
+const resetPythonCode = `# Python Code Snippet
+print("Hello, World!")`;
+
 export default {
   set: codeStore.set,
   subscribe: codeStore.subscribe,
   resetCode: (boardType: MicroControllerType) =>
     codeStore.set({ code: resetCode, boardType }),
+  resetPythonCode: () =>
+    codeStore.set({ code: resetPythonCode, boardType: "python"})
 };


### PR DESCRIPTION
I have added the language selection dropdown under settings tab, and it shows a hardcoded python snippet whenever python is chosen.

- For now the code defaults to C as defined under `firebase/model.ts`. 
- Whenever the language is changed, a reactive statement defined under settings tab, shows the hardcoded python snippet. Maybe an additional support for C code is also possible, if needed, but I haven't looked at it much.
- For now, the generated Python code is hardcoded as defined under `resetPythonCode` variable in `stores/codes/code.store.ts`
- I have also added some syntax highlighting for Python as well. It triggers when the `resetPythonCode` function is used.